### PR TITLE
chore: update netnexus-ui to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "iconv-lite": "^0.6.3",
                 "ipaddr.js": "^2.1.0",
                 "net-snmp": "^3.26.3",
-                "netnexus-ui": "0.2.0",
+                "netnexus-ui": "1.0.0",
                 "ssh2": "^1.15.0"
             },
             "devDependencies": {
@@ -7617,9 +7617,9 @@
             }
         },
         "node_modules/netnexus-ui": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-0.2.0.tgz",
-            "integrity": "sha512-8d0iQJLEs9qhOPOIPslMQVeZgHBgMDdROBh+GWAFeHL3hmQ0jcy4x8qcvcCzCYxxw77bkkQSehkw/qBPsKgkXw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.0.tgz",
+            "integrity": "sha512-wRFjHi4zecvffWwge1j9Y9+Y56yzl4xuo1Ah+EJIOqzaM27cpCORH/y4JpTjfYefkXhqiFqCLd8cXmZc8IUXgg==",
             "dependencies": {
                 "@lucide/vue": "^1.24.0"
             },
@@ -15867,9 +15867,9 @@
             }
         },
         "netnexus-ui": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-0.2.0.tgz",
-            "integrity": "sha512-0GWc5kGlt2ohiUzDJNAD6gq+81XLkDI20aATZ2dxO2VjBt+SkWHw18vCxnyegbOYeTk+5N62ckZP7JATWqbrDQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.0.tgz",
+            "integrity": "sha512-wRFjHi4zecvffWwge1j9Y9+Y56yzl4xuo1Ah+EJIOqzaM27cpCORH/y4JpTjfYefkXhqiFqCLd8cXmZc8IUXgg==",
             "requires": {
                 "@lucide/vue": "^1.24.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "iconv-lite": "^0.6.3",
                 "ipaddr.js": "^2.1.0",
                 "net-snmp": "^3.26.3",
-                "netnexus-ui": "1.0.0",
+                "netnexus-ui": "1.0.1",
                 "ssh2": "^1.15.0"
             },
             "devDependencies": {
@@ -7617,9 +7617,9 @@
             }
         },
         "node_modules/netnexus-ui": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.0.tgz",
-            "integrity": "sha512-wRFjHi4zecvffWwge1j9Y9+Y56yzl4xuo1Ah+EJIOqzaM27cpCORH/y4JpTjfYefkXhqiFqCLd8cXmZc8IUXgg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.1.tgz",
+            "integrity": "sha512-rpZnk1ijvz4tK3IfL9WR5BkyUSr7i9vFCsIvjMZ2h9tC6nK60Fj4vrrSaxZmstWOXl56cj9fZCvy3JtHD+fciw==",
             "dependencies": {
                 "@lucide/vue": "^1.24.0"
             },
@@ -15867,9 +15867,9 @@
             }
         },
         "netnexus-ui": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.0.tgz",
-            "integrity": "sha512-wRFjHi4zecvffWwge1j9Y9+Y56yzl4xuo1Ah+EJIOqzaM27cpCORH/y4JpTjfYefkXhqiFqCLd8cXmZc8IUXgg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/netnexus-ui/-/netnexus-ui-1.0.1.tgz",
+            "integrity": "sha512-rpZnk1ijvz4tK3IfL9WR5BkyUSr7i9vFCsIvjMZ2h9tC6nK60Fj4vrrSaxZmstWOXl56cj9fZCvy3JtHD+fciw==",
             "requires": {
                 "@lucide/vue": "^1.24.0"
             }

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
         "iconv-lite": "^0.6.3",
         "ipaddr.js": "^2.1.0",
         "net-snmp": "^3.26.3",
-        "netnexus-ui": "1.0.0",
+        "netnexus-ui": "1.0.1",
         "ssh2": "^1.15.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
         "iconv-lite": "^0.6.3",
         "ipaddr.js": "^2.1.0",
         "net-snmp": "^3.26.3",
-        "netnexus-ui": "0.2.0",
+        "netnexus-ui": "1.0.0",
         "ssh2": "^1.15.0"
     }
 }

--- a/test/ci/ui_dependency_guard.js
+++ b/test/ci/ui_dependency_guard.js
@@ -36,7 +36,6 @@ const migrationFiles = [
     path.join(projectRoot, 'vite.config.js'),
     path.join(projectRoot, 'package.json'),
     path.join(projectRoot, 'README.md'),
-    path.join(projectRoot, 'CLAUDE.md'),
     path.join(projectRoot, 'scripts', 'captureDocsScreenshots.js')
 ];
 const legacyPatterns = [

--- a/test/ci/ui_local_development.js
+++ b/test/ci/ui_local_development.js
@@ -9,7 +9,9 @@ const {
     resolveLocalUiRoot
 } = require('../../scripts/local-ui-source');
 
-const projectRoot = path.resolve(__dirname, '..', '..');
+const projectRoot = process.env.NETNEXUS_SOURCE_PROJECT_ROOT
+    ? path.resolve(process.env.NETNEXUS_SOURCE_PROJECT_ROOT)
+    : path.resolve(__dirname, '..', '..');
 const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
 
 assert.equal(resolveLocalUiRoot(projectRoot, ''), null, 'normal builds must not probe a sibling UI repository');

--- a/test/e2e/ui-components.spec.js
+++ b/test/e2e/ui-components.spec.js
@@ -324,6 +324,12 @@ test.describe('Custom UI component interactions', () => {
         await page.goto('/#/tools/packet-parser');
         await expect(page.getByText('报文解析器', { exact: true })).toBeVisible();
 
+        const expandSidebarButton = page.getByRole('button', { name: '展开侧边栏' });
+        if (await expandSidebarButton.isVisible()) {
+            await expandSidebarButton.evaluate(button => button.click());
+        }
+        await expect(page.locator('.sidebar-brand-logo')).toBeVisible();
+
         const snapshot = await page.evaluate(() => {
             const sider = document.querySelector('.main-layout > .sider');
             const sidebarNav = sider.querySelector('.sidebar-nav');

--- a/test/e2e/ui-components.spec.js
+++ b/test/e2e/ui-components.spec.js
@@ -1002,7 +1002,7 @@ test.describe('Custom UI component interactions', () => {
                     ghostHoverBackground: readToken('backgroundColor', '--nn-color-bg-card-head-ghost-hover'),
                     ghostText: readToken('color', '--nn-color-text-card-head-ghost'),
                     ghostBorder: readToken('borderColor', '--nn-color-border-card-head-ghost'),
-                    primary: readToken('backgroundColor', '--nn-color-primary'),
+                    primaryActive: readToken('backgroundColor', '--nn-color-primary-active'),
                     inverseText: readToken('color', '--nn-color-text-inverse')
                 };
                 probe.remove();
@@ -1022,12 +1022,12 @@ test.describe('Custom UI component interactions', () => {
 
         await analysisToggle.click();
         await expect(analysisToggle).toHaveAttribute('aria-checked', 'true');
-        await expectHeaderSwitchTokens(analysisToggle, '--nn-color-primary', '--nn-color-text-inverse');
+        await expectHeaderSwitchTokens(analysisToggle, '--nn-color-primary-active', '--nn-color-text-inverse');
         const generatedAt = assurancePage.locator('.generated-at');
         await expect(generatedAt).toHaveText('更新于 E2E-TIME');
 
         const onAppearance = await readHeaderAppearance();
-        expect(onAppearance.toggleBackground).toBe(onAppearance.primary);
+        expect(onAppearance.toggleBackground).toBe(onAppearance.primaryActive);
         expect(onAppearance.toggleBackground).not.toBe(onAppearance.headerBackground);
         expect(onAppearance.handleBackground).toBe(onAppearance.inverseText);
         expect(onAppearance.handleBackground).not.toBe(onAppearance.toggleBackground);


### PR DESCRIPTION
## Summary
- update the pinned `netnexus-ui` dependency from 0.2.0 to 1.0.1
- keep the UI dependency guard aligned with the published package
- allow local UI source development through `NETNEXUS_SOURCE_PROJECT_ROOT`
- make packaged visual tests deterministic and align their switch token contract with netnexus-ui 1.0.1

## Validation
- fresh `npm ci --no-audit --no-fund`
- `npm run lint`
- `node test/ci/yang_libyang_runtime.js`
- `npm test`
- `npm run test:ci:minified`
- `npm run build`
- full `npm run test:e2e`: 132 passed, 16 skipped
- `npm run test:packaged:sqlite`
- netnexus-ui 1.0.1 registry integrity matches the lockfile